### PR TITLE
Default to listen on port 80 in Apache stencil

### DIFF
--- a/stencils/apache/templates/default/ports.conf.erb
+++ b/stencils/apache/templates/default/ports.conf.erb
@@ -2,7 +2,7 @@
 # have to change the VirtualHost statement in
 # /etc/apache2/sites-enabled/000-default.conf
 
-Listen <%= @my_ip %>:8080
+Listen <%= @my_ip %>:80
 
 <IfModule ssl_module>
 	Listen <%= @my_ip %>:443


### PR DESCRIPTION
Partially resolves #18