### PR TITLE
 Use environment variables for custom kitchen configs

### DIFF
--- a/base/Rakefile
+++ b/base/Rakefile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'bundler/setup'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/base/Rakefile
+++ b/base/Rakefile
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'bundler/setup'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
@@ -6,46 +8,35 @@ require 'kitchen'
 
 # Style tests. Rubocop and Foodcritic
 namespace :style do
-  desc 'Run Ruby style checks'
-  RuboCop::RakeTask.new(:ruby)
-
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |t|
-    t.options = { search_gems: true,
-                  fail_tags: ['correctness,rackspace,rackspace-support'],
-                  chef_version: '11.16.4'
-                }
+    t.options = {
+      search_gems: true,
+      fail_tags: %w(any),
+      # FC015: Consider converting definition to a LWRP (allow definitions without complaining)
+      tags: %w(~FC015),
+      chef_version: '12.1.1'
+    }
   end
+
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
 end
 
 desc 'Run all style checks'
 task style: ['style:chef', 'style:ruby']
 
 # Integration tests. Kitchen.ci
-namespace :integration do
-  desc 'Run Test Kitchen with Vagrant'
-  task :vagrant do
-    Kitchen.logger = Kitchen.default_file_logger
-    Kitchen::Config.new.instances.each do |instance|
-      instance.test(:always)
-    end
-  end
-
-  desc 'Run Test Kitchen with cloud plugins'
-  task :cloud do
-    if ENV['CI'] == 'true'
-      Kitchen.logger = Kitchen.default_file_logger
-      @loader = Kitchen::Loader::YAML.new(local_config: '/var/lib/jenkins/.kitchen/config.yml')
-      config = Kitchen::Config.new(loader: @loader)
-      config.instances.each do |instance|
-        instance.test(:always)
-      end
-    end
+task :integration do
+  desc 'Run Test Kitchen'
+  Kitchen.logger = Kitchen.default_file_logger
+  @loader = Kitchen::Loader::YAML.new(
+    local_config: ENV['KITCHEN_LOCAL_YAML']
+  )
+  Kitchen::Config.new(loader: @loader).instances.each do |instance|
+    instance.test(:always)
   end
 end
 
-desc 'Run all tests on CI Platform'
-task ci: ['style', 'integration:cloud']
-
 # Default
-task default: ['style', 'integration:vagrant']
+task default: ['style', 'integration']

--- a/base/Rakefile
+++ b/base/Rakefile
@@ -13,7 +13,7 @@ namespace :style do
       fail_tags: %w(any),
       # FC015: Consider converting definition to a LWRP (allow definitions without complaining)
       tags: %w(~FC015),
-      chef_version: '12.1.1'
+      chef_version: '12.2.1'
     }
   end
 


### PR DESCRIPTION
This allows identical rake commands to be used across local/CI tools by defining KITCHEN_LOCAL_YAML environment variable when needed. Any CI environment should be capable of setting this. This also reduces code complexity of Rakefile and makes Kitchen launched by the Rakefile behave the same way as Kitchen CLI tools.

Also ignore foodcritic warnings about converting definitions to LWRPs, and update Chef version.